### PR TITLE
No explicit bosh-lite target

### DIFF
--- a/bosh-lite/make_manifest_spiff_mysql
+++ b/bosh-lite/make_manifest_spiff_mysql
@@ -16,7 +16,5 @@ DIRECTOR_UUID=$(bosh status | grep UUID | awk '{print $2}')
 echo $DIRECTOR_UUID
 perl -pi -e "s/PLACEHOLDER-DIRECTOR-UUID/$DIRECTOR_UUID/g" bosh-lite/tmp/cf-mysql-stub-with-uuid.yml
 
-bosh target https://192.168.50.4:25555
 $MYSQL_RELEASE_DIR/generate_deployment_manifest warden bosh-lite/tmp/cf-mysql-stub-with-uuid.yml > bosh-lite/manifests/cf-mysql-manifest.yml
 bosh deployment bosh-lite/manifests/cf-mysql-manifest.yml
-


### PR DESCRIPTION
AWS bosh-lite may have different IP (e.g. https://trycf.starkandwayne.com/)

Also, it is too late to try to target bosh - the script already ran 'bosh status'.
