### PR TITLE
[bosh-lite] Auto-detect the current cf api domain

### DIFF
--- a/bosh-lite/cf-mysql-stub-spiff.yml
+++ b/bosh-lite/cf-mysql-stub-spiff.yml
@@ -16,7 +16,7 @@ jobs:
       auth_password: password
       auth_username: admin
       cookie_secret: 94046872-2602-4ca6-8d07-8b0da9762477
-      cc_api_uri: https://api.10.244.0.34.xip.io
+      cc_api_uri: https://api.CF_DOMAIN
       skip_ssl_validation: true
       services:
       - name: p-mysql
@@ -44,8 +44,8 @@ jobs:
         admin_password: admin
         skip_ssl_validation: true
 meta:
-  apps_domain: 10.244.0.34.xip.io
-  system_domain: &SYSTEM_DOMAIN 10.244.0.34.xip.io
+  apps_domain: CF_DOMAIN
+  system_domain: &SYSTEM_DOMAIN CF_DOMAIN
   external_domain: *SYSTEM_DOMAIN
   nats:
     machines:

--- a/bosh-lite/make_manifest_spiff_mysql
+++ b/bosh-lite/make_manifest_spiff_mysql
@@ -13,8 +13,11 @@ mkdir -p bosh-lite/tmp
 mkdir -p bosh-lite/manifests
 cp bosh-lite/cf-mysql-stub-spiff.yml bosh-lite/tmp/cf-mysql-stub-with-uuid.yml
 DIRECTOR_UUID=$(bosh status | grep UUID | awk '{print $2}')
-echo $DIRECTOR_UUID
+echo bosh director UUID $DIRECTOR_UUID
+CF_DOMAIN=$(cf api | awk '{print $3}' | sed -e 's/https.*api\.//g')
+echo cf domain $CF_DOMAIN
 perl -pi -e "s/PLACEHOLDER-DIRECTOR-UUID/$DIRECTOR_UUID/g" bosh-lite/tmp/cf-mysql-stub-with-uuid.yml
+perl -pi -e "s/CF_DOMAIN/$CF_DOMAIN/g" bosh-lite/tmp/cf-mysql-stub-with-uuid.yml
 
 $MYSQL_RELEASE_DIR/generate_deployment_manifest warden bosh-lite/tmp/cf-mysql-stub-with-uuid.yml > bosh-lite/manifests/cf-mysql-manifest.yml
 bosh deployment bosh-lite/manifests/cf-mysql-manifest.yml


### PR DESCRIPTION
For bosh-lite on AWS, the domain uses an AWS Elastic IP. This patch determines the current domain from `cf api`.
