### PR TITLE
BOSH auto-sizes resource pools now

### DIFF
--- a/templates/cf-mysql-template.yml
+++ b/templates/cf-mysql-template.yml
@@ -35,7 +35,6 @@ networks: (( merge ))
 resource_pools:
   - name: services-small
     network: services1
-    size: (( auto ))
     stemcell: (( merge ))
     cloud_properties: (( merge ))
 


### PR DESCRIPTION
This is great for errands - their VMs don't get created until the errand is being run.
