### PR TITLE
Updating sample stub to allow self signed certificates

### DIFF
--- a/templates/sample_stubs/sample_aws_stub.yml
+++ b/templates/sample_stubs/sample_aws_stub.yml
@@ -21,7 +21,7 @@ properties:
     admin_username: YOUR_CF_ADMIN_USERNAME
     admin_password: YOUR_CF_ADMIN_PASSWORD
     skip_ssl_validation: false
-    api_url: YOUR_CF_API_URI
+    api_url: https://YOUR_CF_API_URI # Note this should be in the form of a full URI - ie include http: or https:
 
   template_only:
     aws:
@@ -57,6 +57,7 @@ jobs:
     auth_username: A_USERNAME_YOU_MAKE_UP # eg. cc
     auth_password: A_PASSWORD_YOU_MAKE_UP
     cc_api_uri: (( .properties.cf.api_url ))
+    skip_ssl_validation: (( .properties.cf.skip_ssl_validation ))
     cookie_secret: A_PASSWORD_YOU_MAKE_UP
     services:
       - name: p-mysql

--- a/templates/sample_stubs/sample_vsphere_stub.yml
+++ b/templates/sample_stubs/sample_vsphere_stub.yml
@@ -51,6 +51,7 @@ jobs:
     auth_username: A_USERNAME_YOU_MAKE_UP #eg. cc
     auth_password: A_PASSWORD_YOU_MAKE_UP
     cc_api_uri: (( .properties.cf.api_url ))
+    skip_ssl_validation: (( .properties.cf.skip_ssl_validation ))
     cookie_secret: A_PASSWORD_YOU_MAKE_UP
     services:
     - name: p-mysql


### PR DESCRIPTION
While deploying cf-mysql-broker, we found that if you do not include http or https in the cc_api_uri the broker defaults to generic, which causes an error. Added a note to the AWS sample stuff for consistency with the vSphere stub.

Updated the sample stubs to include passing of the skip_ssl_validation flag to enable self signed certs.

Sorry I hosed my repo with a badly though out force push...