### PR TITLE
Updated steps to run a pre-built final BOSH release

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,8 @@ You can use a pre-built final release or build a release from HEAD. Final releas
 
   ```
   $ cd ~/workspace/cf-mysql-release
-  $ ./update
   $ git checkout v12
-  $ git submodule update --recursive
+  $ ./update
   ```
 
 1. Run the upload command, referencing one of the config files in the `releases` directory.


### PR DESCRIPTION
Update should be run _after_ the appropriate revision is checked out.
