### PR TITLE
Update bosh lite deployment instructions for number of nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,11 @@ If deploying an **older** final release than the latest, check out the tag for t
 
 #### BOSH-lite<a name="bosh-lite"></a>
 
-1. Generate the manifest using a bosh-lite specific script and a stub provided for you, `bosh-lite/cf-mysql-stub-spiff.yml`.
+1. Generate the manifest using a bosh-lite specific script and a stub provided for you based on the 
+  number of nodes that you would like, 1, 2 or 3 (the default).
 
     ```
-    $ ./bosh-lite/make_manifest_spiff_mysql
+    $ ./bosh-lite/make_manifest_spiff_mysql <number of nodes>
     ```
     The resulting file, `bosh-lite/manifests/cf-mysql-manifest.yml` is your deployment manifest. To modify the deployment configuration, you can edit the stub and regenerate the manifest or edit the manifest directly.
 


### PR DESCRIPTION
It looks like this has changed and the readme never got updated. This branch will start outlining those changes.

This is a result of the LAMB team in Boulder trying to deploy to local bosh lite.

This is a work in progress.