### PR TITLE
Revert "Update README.md - Fix for Proxy Link"

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ The following links show how this release implements [Dashboard SSO](http://docs
 
 ## Proxy
 
-More extensive proxy documentation can be found [here](https://github.com/cloudfoundry/cf-mysql-release/blob/master/docs/proxy.md)
+More extensive proxy documentation can be found [here](https://github.com/cloudfoundry/cf-mysql-release/docs/proxy.md)
 
 
 Traffic to the MySQL cluster is routed through one or more proxy nodes. The current proxy implementation is [Switchboard](https://github.com/cloudfoundry-incubator/switchboard). This proxy acts as an intermediary between the client and the MySQL server - providing failover between MySQL nodes. The number of nodes is configured by the job instance count in the deployment manifest.


### PR DESCRIPTION
Reverts cloudfoundry/cf-mysql-release#57

I'm sorry, I had to revert this. I merged it against master, which was incorrect.

This pull request has been reviewed, and it sounds good. BUT, it's filed against the wrong branch - it should be filed against develop, not master. We've only just published a [CONTRIBUTING](https://github.com/cloudfoundry/cf-mysql-release/blob/develop/CONTRIBUTING.md) file, please check it out.

If you could please retract this PR, and re-submit it against develop, I'll be very grateful.

--
  Marco Nicosia
  Product Manager
  Pivotal Software, Inc.
