### PR TITLE
Update README.md - Fix for Proxy Link - to the develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ The following links show how this release implements [Dashboard SSO](http://docs
 
 ## Proxy
 
-More extensive proxy documentation can be found [here](https://github.com/cloudfoundry/cf-mysql-release/docs/proxy.md)
+More extensive proxy documentation can be found [here](https://github.com/cloudfoundry/cf-mysql-release/blob/master/docs/proxy.md)
 
 
 Traffic to the MySQL cluster is routed through one or more proxy nodes. The current proxy implementation is [Switchboard](https://github.com/cloudfoundry-incubator/switchboard). This proxy acts as an intermediary between the client and the MySQL server - providing failover between MySQL nodes. The number of nodes is configured by the job instance count in the deployment manifest.


### PR DESCRIPTION
This request was reverted back as asked by Marcio and now delivering to the develop branch.

Correct proxy link is provided now. 
https://github.com/cloudfoundry/cf-mysql-release/blob/master/docs/proxy.md
