### PR TITLE
Generate deployment manifest script: fix error when running without args on a recent bash versions

### DIFF
--- a/generate_deployment_manifest
+++ b/generate_deployment_manifest
@@ -4,14 +4,14 @@ templates=$(dirname $0)/templates
 
 infrastructure=$1
 
-shift
-
 if [ "$infrastructure" != "aws" ] && \
     [ "$infrastructure" != "warden" ] && \
     [ "$infrastructure" != "vsphere" ] ; then
   echo "usage: ./generate_deployment_manifest <aws|warden|vsphere> [stubs...]"
   exit 1
 fi
+
+shift
 
 spiff merge \
   $templates/cf-mysql-template.yml \


### PR DESCRIPTION
On some versions of bash _shift_ command fails with error "shift: can't shift that many" when no args were given, so user gets error instead of usage info.

Test script:
```
#!/bin/bash

echo "Before shift:" $@
shift
echo "After shift:" $@
```

Bash 3.2.57, Mac OS 10.10
```
$ sh test.sh 1 2 3
Before shift: 1 2 3
After shift: 2 3
```
```
$ sh test.sh 
Before shift:
After shift:
```

Bash 4.3.11, Ubuntu 14.04:

```
$ sh test.sh 1 2 3
Before shift: 1 2 3
After shift: 2 3
```
```
$ sh test.sh 
Before shift:
test.sh: 4: shift: can't shift that many
```