### PR TITLE
Deploy without a CF

### DIFF
--- a/bosh-lite/mysql-stub-spiff-3-node.yml
+++ b/bosh-lite/mysql-stub-spiff-3-node.yml
@@ -1,0 +1,41 @@
+---
+name: cf-warden-mysql
+director_uuid: PLACEHOLDER-DIRECTOR-UUID
+releases:
+  - name: cf-mysql
+    version: latest
+
+properties:
+  domain: (( merge || "" ))
+
+jobs:
+  - name: mysql_z1
+    instances: 1
+    networks:
+    - name: mysql1
+      static_ips:
+      - 10.244.7.2
+    properties:
+      <<: (( merge || nil ))
+      admin_password: password
+      cluster_ips: (( jobs.mysql_z1.networks.[0].static_ips ))
+  - name: mysql_z2
+    instances: 1
+  - name: mysql_z3
+    instances: 1
+  - name: cf-mysql-broker_z1
+    instances: 0
+  - name: cf-mysql-broker_z2
+    instances: 0
+  - name: proxy_z1
+    properties:
+      <<: (( merge || nil ))
+      proxy:
+        <<: (( merge || nil ))
+        api_username: username
+        api_password: password
+  - name: proxy_z2
+    instances: 1
+  - name: acceptance-tests
+    properties:
+      no_cf: true

--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -40,6 +40,9 @@ properties:
   smoke_tests_only:
     description: 'Instead of running the full acceptance test suite, only run a shorter smoke test'
     default: true
+  no_cf:
+    description: 'If this release has been deployed without CF, only run the proxy tests'
+    default: false
 
   proxy.external_host:
     description: 'Proxy external host (e.g. p-mysql.example.com => proxy-0.p-mysql.example.com)'

--- a/jobs/acceptance-tests/templates/errand.sh.erb
+++ b/jobs/acceptance-tests/templates/errand.sh.erb
@@ -1,52 +1,38 @@
 #!/bin/bash
 set -e -x
 
+<% if p('no_cf') %>
+exit 0
+<% end %>
+
 cd /var/vcap/packages/acceptance-tests/src/github.com/cloudfoundry-incubator/cf-mysql-acceptance-tests
 
-cat > integration_config.json <<EOF
-{
-  "api":           "<%= p('cf.api_url') %>",
-  "apps_domain":   "<%= p('cf.apps_domain') %>",
-  "admin_user":    "<%= p('cf.admin_username') %>",
-  "broker_host":   "<%= p('broker.host') %>",
-  "service_name":  "<%= p('service.name') %>",
-  <% if p('org_name') %>
-  "org_name": "<%= p('org_name') %>",
-  <% end %>
-  "plans": [
-  <% plans = p('service.plans')
-  plans.each do |plan| %>
-    {
-      "plan_name": "<%= plan['plan_name'] %>",
-      "max_storage_mb": <%= plan['max_storage_mb'] %>,
-      "max_user_connections": <%= plan['max_user_connections'] || p('service.max_user_connections_default')%>
-  <% if plan != plans.last %>
-    },
-  <% else %>
-    }
-  <% end
-  end%>
-  ],
-  "skip_ssl_validation": <%= p('cf.skip_ssl_validation') %>,
-  "proxy": {
-    "external_host": "<%= p('proxy.external_host') %>",
-    "api_username": "<%= p('proxy.api_username') %>",
-    "api_password": "<%= p('proxy.api_password') %>",
-    "api_force_https": <%= p('proxy.api_force_https') %>,
-    "skip_ssl_validation": <%= p('proxy.skip_ssl_validation') %>
-  },
-  "timeout_scale": <%= p('timeout_scale') %>,
-EOF
+<%
+integration_config = properties.cf.to_h
+integration_config[:proxy] = properties.proxy.to_h
+integration_config[:timeout_scale] = properties.timeout_scale
+
+integration_config[:org_name] = properties.org_name if properties.org_name
+integration_config[:api] = properties.cf.api_url if properties.cf
+integration_config[:admin_user] = properties.cf.admin_username if properties.cf
+integration_config[:broker_host] = properties.broker.host if properties.broker
+if properties.service
+  integration_config[:service_name] = properties.service.name
+  integration_config[:plans] = properties.service.plans.map do |plan|
+    { max_user_connections: properties.service.max_user_connections_default }.merge(plan.to_h)
+  end
+end
+%>
 
 # don't expose passwords
 set +x
-
-cat >> integration_config.json <<EOF
-  "admin_password":   "<%= p('cf.admin_password') %>"
-}
+cat > integration_config.json <<EOF
+<%=
+require "json"
+JSON.dump(integration_config)
+%>
 EOF
-
-# set -x
+set -x
 
 export GOPATH=/var/vcap/packages/acceptance-tests
 export GOROOT=/var/vcap/packages/golang

--- a/jobs/cf-mysql-broker/templates/registrar_settings.yml.erb
+++ b/jobs/cf-mysql-broker/templates/registrar_settings.yml.erb
@@ -1,3 +1,4 @@
+<% if_p('nats.machines') do |_| %>
 message_bus_servers:
 <% p('nats.machines').each do |ip| %>
     - host: <%= ip %>:<%= p('nats.port') %>
@@ -11,3 +12,4 @@ health_checker:
     name: script
     interval_in_seconds: 10
     healthcheck_script_path: /var/vcap/jobs/cf-mysql-broker/bin/healthcheck.sh
+<% end %>

--- a/jobs/cf-mysql-broker/templates/route-registrar_ctl.erb
+++ b/jobs/cf-mysql-broker/templates/route-registrar_ctl.erb
@@ -23,10 +23,15 @@ start)
 
   pid_guard $PIDFILE $JOB_NAME
 
+<% if_p('nats.machines') { |_| %>
   /var/vcap/packages/route-registrar/bin/route-registrar \
   -pidfile=$PIDFILE \
   -configPath=$CONFIG_FILE \
   >>$LOG_DIR/route-registrar.stdout.log 2>>$LOG_DIR/route-registrar.stderr.log&
+<% }.else { %>
+  echo $$ > $PIDFILE
+  kill -STOP $$
+<% } %>
 ;;
 
 stop)

--- a/jobs/proxy/templates/route-registrar.yml.erb
+++ b/jobs/proxy/templates/route-registrar.yml.erb
@@ -1,3 +1,4 @@
+<% if_p('nats.machines') do |_| %>
 message_bus_servers:
 <% p('nats.machines').each do |ip| %>
     - host: <%= ip %>:<%= p('nats.port') %>
@@ -7,3 +8,4 @@ message_bus_servers:
 external_host: proxy-<%= index %>.<%= p('external_host') %>
 external_ip: <%= spec.networks.send(p('network_name')).ip %>
 port: <%= p('proxy.api_port') %>
+<% end %>

--- a/jobs/proxy/templates/route-registrar_ctl.erb
+++ b/jobs/proxy/templates/route-registrar_ctl.erb
@@ -23,10 +23,15 @@ start)
 
   pid_guard $PIDFILE $JOB_NAME
 
+<% if_p('nats.machines') { |_| %>
   /var/vcap/packages/route-registrar/bin/route-registrar \
   -pidfile=$PIDFILE \
   -configPath=$CONFIG_FILE \
   >>$LOG_DIR/route-registrar.stdout.log 2>>$LOG_DIR/route-registrar.stderr.log&
+<% }.else { %>
+  echo $$ > $PIDFILE
+  kill -STOP $$
+<% } %>
 ;;
 
 stop)

--- a/scripts/create_integration_test_config
+++ b/scripts/create_integration_test_config
@@ -54,12 +54,12 @@ cat > ${CONFIG_LOCATION} <<EOF
   "service_name": "p-mysql",
   "plans" : [
     {
-      "plan_name": "100mb",
+      "name": "100mb",
       "max_user_connections": 20,
       "max_storage_mb": ${SMALL_PLAN_SIZE}
     },
     {
-      "plan_name": "1gb",
+      "name": "1gb",
       "max_user_connections": 40,
       "max_storage_mb": ${LARGE_PLAN_SIZE}
     }

--- a/templates/cf-mysql-template.yml
+++ b/templates/cf-mysql-template.yml
@@ -9,18 +9,18 @@ meta:
   syslog_aggregator: ~
 
 properties:
-  app_domains: (( merge ))
-  domain: (( merge ))
+  app_domains: (( merge || nil ))
+  domain: (( merge || nil ))
   nats:
-    user: (( merge ))
-    password: (( merge ))
-    port: (( merge ))
-    machines: (( merge ))
+    user: (( merge || nil ))
+    password: (( merge || nil ))
+    port: (( merge || nil ))
+    machines: (( merge || nil ))
   cf:
     api_url: (( "https://api." .properties.domain ))
-    admin_username: (( merge ))
-    admin_password: (( merge ))
-    apps_domain: (( .properties.app_domains.[0] ))
+    admin_username: (( merge || " " ))
+    admin_password: (( merge || " " ))
+    apps_domain: (( .properties.app_domains.[0] || " " ))
     skip_ssl_validation: (( merge || nil ))
   default_mysql_cluster_ips:
   - (( jobs.mysql_z1.networks.mysql1.static_ips.[0] || nil ))
@@ -168,7 +168,7 @@ jobs:
     proxy:
       <<: (( merge || nil ))
       health_port: (( merge || nil ))
-      api_force_https: (( merge || nil ))
+      api_force_https: (( merge || false ))
       api_username: (( merge ))
       api_password: (( merge ))
     cluster_ips: (( jobs.mysql_z1.properties.cluster_ips ))
@@ -213,9 +213,9 @@ jobs:
     network_name: mysql1
     ssl_enabled: (( merge || nil ))
     skip_ssl_validation: (( .properties.cf.skip_ssl_validation ))
-    auth_username: (( merge ))
-    auth_password: (( merge ))
-    cookie_secret: (( merge ))
+    auth_username: (( merge || nil ))
+    auth_password: (( merge || nil ))
+    cookie_secret: (( merge || nil ))
     external_host: (( merge || "p-mysql." .properties.domain ))
     cc_api_uri: (( .properties.cf.api_url ))
     nats: (( .properties.nats ))
@@ -237,8 +237,8 @@ jobs:
         supportUrl: "https://support.pivotal.io"
       dashboard_client:
         id: p-mysql
-        secret: (( merge ))
-      plans: (( merge ))
+        secret: (( merge || nil ))
+      plans: (( merge || [] ))
     mysql_node:
       host: (( merge || jobs.proxy_z1.networks.mysql1.static_ips.[0] ))
       admin_password: (( jobs.mysql_z1.properties.admin_password ))
@@ -321,11 +321,4 @@ jobs:
     service:
       max_user_connections_default: (( jobs.cf-mysql-broker_z1.properties.max_user_connections_default ))
       name: (( jobs.cf-mysql-broker_z1.properties.services.[0].name ))
-      plans:
-        - plan_name: (( jobs.cf-mysql-broker_z1.properties.services.[0].plans.[0].name ))
-          max_storage_mb: (( jobs.cf-mysql-broker_z1.properties.services.[0].plans.[0].max_storage_mb ))
-          max_user_connections: (( jobs.cf-mysql-broker_z1.properties.services.[0].plans.[0].max_user_connections ))
-        - plan_name: (( jobs.cf-mysql-broker_z1.properties.services.[0].plans.[1].name ))
-          max_storage_mb: (( jobs.cf-mysql-broker_z1.properties.services.[0].plans.[1].max_storage_mb ))
-          max_user_connections: (( jobs.cf-mysql-broker_z1.properties.services.[0].plans.[1].max_user_connections ))
-
+      plans: (( jobs.cf-mysql-broker_z1.properties.services.[0].plans ))


### PR DESCRIPTION
This is a great bosh MySQL release that might not always be deployed alongside a CloudFoundry. All CF components are still in the release, but we want to create a manifest that disables them without breaking the deployment.

The mysql-stub-spiff-3-node.yml can be used on a clean bosh-lite, without any CF. We'll try this on AWS next and come back with manifest additions if required.

Also relates to cloudfoundry-incubator/cf-mysql-acceptance-tests#2