### PR TITLE
allow configureable smoke test password

### DIFF
--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -40,6 +40,9 @@ properties:
   smoke_tests_only:
     description: 'Instead of running the full acceptance test suite, only run a shorter smoke test'
     default: true
+  smoke_test_password:
+    description: 'Password for smoke tests to comply with CF password policy, if exists.'
+    default: 'meow'
 
   proxy.external_host:
     description: 'Proxy external host (e.g. p-mysql.example.com => proxy-0.p-mysql.example.com)'

--- a/jobs/acceptance-tests/templates/errand.sh.erb
+++ b/jobs/acceptance-tests/templates/errand.sh.erb
@@ -10,6 +10,7 @@ cat > integration_config.json <<EOF
   "admin_user":    "<%= p('cf.admin_username') %>",
   "broker_host":   "<%= p('broker.host') %>",
   "service_name":  "<%= p('service.name') %>",
+  "test_password": "<%= p('smoke_test_password') %>",
   <% if p('org_name') %>
   "org_name": "<%= p('org_name') %>",
   <% end %>


### PR DESCRIPTION
CFv213 onwards allows for an optional password policy.
Service releases which use the cf-test-helpers suite should
be able to overwrite the suite's default password (meow) to
avoid failure.

Connected to cloudfoundry-incubator/cf-test-helpers#16