### PR TITLE
Trim release size

### DIFF
--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -19,7 +19,6 @@ packages:
 - galera
 - galera-healthcheck
 - gra-log-purger
-- golang
 - cf-mysql-common
 - syslog_aggregator
 

--- a/jobs/proxy/spec
+++ b/jobs/proxy/spec
@@ -10,7 +10,6 @@ templates:
 
 packages:
 - switchboard
-- golang
 - cf-mysql-common
 - syslog_aggregator
 - cf-mysql-route-registrar

--- a/packages/mariadb/packaging
+++ b/packages/mariadb/packaging
@@ -40,6 +40,8 @@ tar xzf mariadb/mariadb-galera-${MARIADB_VERSION}.tar.gz
   fi
   tail -n 1000 build.out
 
+  rm -rf ${BOSH_INSTALL_TARGET}/mysql-test/
+
   echo -n "${MARIADB_VERSION}-MariaDB" > ${BOSH_INSTALL_TARGET}/VERSION
   cp /var/vcap/packages/galera/garbd ${BOSH_INSTALL_TARGET}/bin/
   cp /var/vcap/packages/galera/libgalera_smm.so ${BOSH_INSTALL_TARGET}/lib/plugin/

--- a/packages/mariadb/packaging
+++ b/packages/mariadb/packaging
@@ -41,6 +41,7 @@ tar xzf mariadb/mariadb-galera-${MARIADB_VERSION}.tar.gz
   tail -n 1000 build.out
 
   rm -rf ${BOSH_INSTALL_TARGET}/mysql-test/
+  strip ${BOSH_INSTALL_TARGET}/{bin,lib,lib/plugin}/* 2> /dev/null || :
 
   echo -n "${MARIADB_VERSION}-MariaDB" > ${BOSH_INSTALL_TARGET}/VERSION
   cp /var/vcap/packages/galera/garbd ${BOSH_INSTALL_TARGET}/bin/


### PR DESCRIPTION
I have a few changes to reduce disk usage in this component:

* mysql and proxy jobs don't need golang during runtime
* The mysql-test dir is over 300MB and isn't used during runtime
* Stripping the mysql binaries reduces their size from 304M -> 132M

If the changes aren't closely related enough, I'd be happy to split them into separate PRs for discussion.
