### PR TITLE
Add ability to override number of compilation workers

### DIFF
--- a/manifest-generation/cf-mysql-template.yml
+++ b/manifest-generation/cf-mysql-template.yml
@@ -5,7 +5,7 @@ director_uuid: (( config_from_cf.cf_director_uuid ))
 releases: (( base_releases additional_releases ))
 
 compilation:
-  workers: 4
+  workers: (( iaas_settings.compilation_workers || 4)) 
   network: mysql1
   reuse_compilation_vms: true
   cloud_properties: (( iaas_settings.compilation_cloud_properties ))

--- a/manifest-generation/examples/aws/iaas-settings.yml
+++ b/manifest-generation/examples/aws/iaas-settings.yml
@@ -62,7 +62,7 @@ iaas_settings:
 
   stemcell: &stemcell
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: latest
+  compilation_workers: 2 # When setting this parameter, it overrides the default number of compilation workers (default=4)
   compilation_cloud_properties:
     instance_type: c4.large
     availability_zone: (( properties.template_only.aws.availability_zone ))

--- a/manifest-generation/examples/aws/iaas-settings.yml
+++ b/manifest-generation/examples/aws/iaas-settings.yml
@@ -62,6 +62,7 @@ iaas_settings:
 
   stemcell: &stemcell
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version: latest
   compilation_workers: 2 # When setting this parameter, it overrides the default number of compilation workers (default=4)
   compilation_cloud_properties:
     instance_type: c4.large

--- a/manifest-generation/examples/vsphere/iaas-settings.yml
+++ b/manifest-generation/examples/vsphere/iaas-settings.yml
@@ -74,6 +74,7 @@ iaas_settings:
   stemcell: &stemcell
     name: bosh-vsphere-esxi-ubuntu-trusty-go_agent
     version: latest
+  compilation_workers: 2 # When setting this parameter, it overrides the default number of compilation workers (default=4)
   compilation_cloud_properties:
     ram: 4096
     disk: 20480


### PR DESCRIPTION
Some Iaas fail with too large concurrent compilation workers. This enables configuring them without manually patching the generated manifest.