### PR TITLE
Add ability to override deployment name

### DIFF
--- a/manifest-generation/cf-mysql-template.yml
+++ b/manifest-generation/cf-mysql-template.yml
@@ -1,5 +1,5 @@
 ---
-name: (( config_from_cf.cf_deployment_name "-mysql" ))
+name: (( property_overrides.deployment_name || config_from_cf.cf_deployment_name "-mysql" ))
 director_uuid: (( config_from_cf.cf_director_uuid ))
 
 releases: (( base_releases additional_releases ))

--- a/manifest-generation/examples/property-overrides.yml
+++ b/manifest-generation/examples/property-overrides.yml
@@ -1,5 +1,6 @@
 property_overrides:
   <<: (( merge || nil ))
+  deployment_name: REPLACE_WITH_YOUR_DEPLOYMENT_NAME # Optional, when setting this parameter, it overrides the hardcoded deployment name
   syslog_aggregator: ~
   standalone: false
   host: REPLACE_WITH_LB_HOSTNAME # Optional, set to your Load Balancer address if configured; delete this line otherwise


### PR DESCRIPTION
For our migration from v25 to v26, we had difficulties with deployment name hard coded. This patch adds the ability to set a personalized deployment name. The property property_overrides.deployment_name does not have to be defined (in this case, it's like the old behaviour).