### PR TITLE
Default cf_mysql.host to nil

### DIFF
--- a/manifest-generation/cf-mysql-template.yml
+++ b/manifest-generation/cf-mysql-template.yml
@@ -56,7 +56,7 @@ properties:
   cf_mysql:
     standalone: (( property_overrides.standalone || false ))
     external_host: (( "p-mysql." .properties.domain ))
-    host: (( property_overrides.host || jobs.proxy_z1.networks.mysql1.static_ips.[0] ))
+    host: (( property_overrides.host || jobs.proxy_z1.networks.mysql1.static_ips.[0] || nil ))
     mysql:
       admin_username: (( property_overrides.mysql.admin_username || nil ))
       admin_password: (( property_overrides.mysql.admin_password ))


### PR DESCRIPTION
If we're deploying single node w/o a proxy, `jobs.proxy_z1.networks.mysql1.static_ips.[0]` will not resolve.
