### PR TITLE
`./scripts/generate-deployment-manifest` now takes a real cf manifest

### DIFF
--- a/manifest-generation/cf-mysql-template.yml
+++ b/manifest-generation/cf-mysql-template.yml
@@ -42,12 +42,11 @@ properties:
     password: (( config_from_cf.nats.password ))
     port: (( config_from_cf.nats.port ))
   app_domains: (( config_from_cf.app_domains ))
-  domain: (( config_from_cf.domain ))
   cf:
     api_url: (( config_from_cf.api_url ))
     app_domains: (( config_from_cf.app_domains ))
-    admin_username: (( config_from_cf.admin_username ))
-    admin_password: (( config_from_cf.admin_password ))
+    admin_username: (( property_overrides.cf.admin_username ))
+    admin_password: (( property_overrides.cf.admin_password ))
     skip_ssl_validation: (( config_from_cf.skip_ssl_validation || nil ))
     smoke_tests:
       use_existing_org: (( config_from_cf.smoke_tests.use_existing_org || nil ))
@@ -55,7 +54,7 @@ properties:
   syslog_aggregator: (( property_overrides.syslog_aggregator || nil ))
   cf_mysql:
     standalone: (( property_overrides.standalone || false ))
-    external_host: (( "p-mysql." .properties.domain ))
+    external_host: (( "p-mysql." .config_from_cf.system_domain ))
     host: (( property_overrides.host || jobs.proxy_z1.networks.mysql1.static_ips.[0] ))
     mysql:
       admin_username: (( property_overrides.mysql.admin_username || nil ))

--- a/manifest-generation/misc-templates/config-from-cf-internal.yml
+++ b/manifest-generation/misc-templates/config-from-cf-internal.yml
@@ -6,13 +6,10 @@ config_from_cf:
     password: (( properties.nats.password ))
     port: (( properties.nats.port ))
     machines: (( properties.nats.machines ))
-  domain: (( properties.domain ))
   system_domain: (( properties.system_domain ))
   app_domains: (( properties.app_domains ))
-  api_url: (( "https://api." properties.domain ))
+  api_url: (( properties.cc.srv_api_uri ))
   skip_ssl_validation: (( properties.skip_ssl_validation ))
-  admin_username: (( properties.admin_username ))
-  admin_password: (( properties.admin_password ))
   smoke_tests:
     use_existing_org: (( properties.smoke_tests.use_existing_org ))
     org: (( properties.smoke_tests.org ))
@@ -32,16 +29,15 @@ config_from_cf:
 name: (( merge ))
 director_uuid: (( merge ))
 properties:
+  cc:
+    srv_api_uri: (( merge ))
   nats:
     user: (( merge ))
     password: (( merge ))
     machines: (( merge ))
     port: (( merge ))
-  domain: (( merge ))
   system_domain: (( merge ))
   app_domains: (( merge ))
-  admin_username: (( merge ))
-  admin_password: (( merge ))
   skip_ssl_validation: (( merge || nil ))
   smoke_tests:
     use_existing_org: (( merge || nil ))

--- a/manifest-generation/misc-templates/config-from-cf.yml
+++ b/manifest-generation/misc-templates/config-from-cf.yml
@@ -6,13 +6,10 @@ config_from_cf:
     password: (( merge ))
     port: (( merge ))
     machines: (( merge ))
-  domain: (( merge ))
   system_domain: (( merge ))
   app_domains: (( merge ))
   api_url: (( merge ))
   skip_ssl_validation: (( merge ))
-  admin_username: (( merge ))
-  admin_password: (( merge ))
   smoke_tests:
     use_existing_org: (( merge ))
     org: (( merge ))


### PR DESCRIPTION
* `admin_username` and `admin_password` come from property overrides now
* use `properties.system_domain` instead of the deprecated and removed
  `properties.domain`
* use the `properties.cc.srv_api_uri` from cf instead of constructing it

Signed-off-by: Andrew Edgar <aedgar@ca.ibm.com>