### PR TITLE
Allow for override of the innodb_buffer_pool_instances

### DIFF
--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -58,6 +58,8 @@ properties:
     default: 65536
   cf_mysql.mysql.innodb_buffer_pool_size:
     description: 'Optional, the size in bytes of the memory buffer InnoDB uses to cache data and indexes of its tables'
+  cf_mysql.mysql.innodb_buffer_pool_instances:
+    description: 'Optional, number of buffer pool instances for InnoDB used if innodb_buffer_pool_size > 1GB'
   cf_mysql.mysql.cluster_ips:
     description: 'List of nodes.  Must have the same number of ips as there are nodes in the cluster'
   cf_mysql.mysql.max_heap_table_size:

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -121,6 +121,9 @@ innodb_stats_persistent = OFF
 <% if_p('cf_mysql.mysql.innodb_buffer_pool_size') do |innodb_buffer_pool_size| %>
 innodb_buffer_pool_size = <%= innodb_buffer_pool_size %>
 <% end %>
+<% if_p('cf_mysql.mysql.innodb_buffer_pool_instances') do |innodb_buffer_pool_instances| %>
+innodb_buffer_pool_instances = <%= innodb_buffer_pool_instances %>
+<% end %>
 
 <% if_p('cf_mysql.mysql.max_connections') do |max_connections| %>
 max_connections = <%= max_connections %>


### PR DESCRIPTION
When you are able to override the innodb_buffer_pool_size you should also have the ability to override the innobd_buffer_pool_instances.

The rule of thumb is if the size is > 1GB you want the number of instances where size / instances is >= 1GB.
