### PR TITLE
Add a way to set `ulimit -n' for the proxy job

### DIFF
--- a/jobs/proxy/spec
+++ b/jobs/proxy/spec
@@ -73,4 +73,6 @@ properties:
   cf_mysql.proxy.consul_service_name:
     description: "Switchboard will register with consul using this name"
     default: "mysql"
-
+  cf_mysql.proxy.max_open_files:
+    description: 'Configure this number to be twice as large as mysql.max_connections'
+    default: 3000

--- a/jobs/proxy/templates/switchboard_ctl.erb
+++ b/jobs/proxy/templates/switchboard_ctl.erb
@@ -11,6 +11,8 @@ export PATH=$GOROOT/bin:$PWD/bin:$PATH
 
 source /var/vcap/packages/cf-mysql-common/pid_utils.sh
 
+ulimit -n <%= p('cf_mysql.proxy.max_open_files') %>
+
 case $1 in
 
   start)


### PR DESCRIPTION
This pr adds a way to set `ulimit` on the proxy servers. A recent change added this capability to the mysql_z instances. The description of the field in the spec also mentions that this value should be set to twice the  value of `max_open_connections` on the mysql instance, since the proxy has a receiving connection from the client and initiates a connection to the backend.

Signed-off-by: Andrew Edgar <aedgar@ca.ibm.com>