### PR TITLE
Make galera port be configurable

### DIFF
--- a/jobs/cf-mysql-broker/spec
+++ b/jobs/cf-mysql-broker/spec
@@ -105,3 +105,6 @@ properties:
   cf_mysql.broker.quota_enforcer.pause:
     description: 'In seconds, the interval that the Quota Enforcer pauses between checks for violators and reformers'
     default: 1
+  cf_mysql.broker.nginx.port:
+    default: 80
+    description: "Port for nginx"

--- a/jobs/cf-mysql-broker/templates/healthcheck.sh.erb
+++ b/jobs/cf-mysql-broker/templates/healthcheck.sh.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-lsof -i :80 2>&1 >> /dev/null
+lsof -i :<%= p('cf_mysql.broker.nginx.port') %> 2>&1 >> /dev/null
 EXIT_CODE=$?
 if [[ $EXIT_CODE -eq 0 ]]; then
   echo 1

--- a/jobs/cf-mysql-broker/templates/registrar_settings.yml.erb
+++ b/jobs/cf-mysql-broker/templates/registrar_settings.yml.erb
@@ -24,7 +24,7 @@ message_bus_servers:
 host: <%= network_ip %>
 routes:
 - name: "broker_<%= index %>"
-  port: 80
+  port: <%= p('cf_mysql.broker.nginx.port') %>
   uris:
   - <%= p('cf_mysql.external_host') %>
   registration_interval: 10s

--- a/jobs/cf-mysql-broker/templates/unicorn.conf.rb.erb
+++ b/jobs/cf-mysql-broker/templates/unicorn.conf.rb.erb
@@ -6,7 +6,7 @@ worker_processes 4
 
 working_directory '/var/vcap/packages/cf-mysql-broker'
 
-listen 80, :tcp_nopush => true
+listen <%= p('cf_mysql.broker.nginx.port') %>, :tcp_nopush => true
 
 pid '/var/vcap/sys/run/cf-mysql-broker/unicorn.pid'
 

--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -49,6 +49,9 @@ properties:
   cf_mysql.mysql.port:
     description: 'Port the mysql server should bind to'
     default: 3306
+  cf_mysql.mysql.galera_port:
+    description: 'Port which garbd listens on'
+    default: 4567
   cf_mysql.mysql.max_connections:
     description: 'Maximum total number of database connections for the node'
     default: 1500

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -45,7 +45,7 @@ nice      = 0
 wsrep_provider=/var/vcap/packages/mariadb/lib/plugin/libgalera_smm.so
 wsrep_provider_options="gcache.size=<%= p('cf_mysql.mysql.gcache_size') %>M;pc.recovery=TRUE;pc.checksum=TRUE"
 wsrep_cluster_address="gcomm://<%= cluster_ips.join(",") %>"
-wsrep_node_address='<%= network_ip %>'
+wsrep_node_address='<%= network_ip %>:<%= p('cf_mysql.mysql.galera_port') %>'
 wsrep_node_name='<%= name %>/<%= index %>'
 wsrep_cluster_name='cf-mariadb-galera-cluster'
 wsrep_sst_method=xtrabackup-v2


### PR DESCRIPTION
Make ports be configurable. Since PCF Dev has all the jobs collocated on one VM, we can't have anything assuming port 80 is free since other services are running on that port.

We built this pull request off of branch: `releases/v26`