### PR TITLE
Add Azure iaas-settings Example

### DIFF
--- a/manifest-generation/examples/azure/iaas-settings.yml
+++ b/manifest-generation/examples/azure/iaas-settings.yml
@@ -1,0 +1,125 @@
+properties:
+  template_only:
+    azure:
+      region1: REPLACE_WITH_REGION_1 # e.g. southcentralus
+      region2: REPLACE_WITH_REGION_2
+      region3: REPLACE_WITH_REGION_3
+      virtual_network_name: REPLACE_WITH_YOUR_VIRTUAL_NETWORK_NAME
+      subnet_names:
+        mysql1: REPLACE_WITH_YOUR_SUBNET_NAME_1
+        mysql2: REPLACE_WITH_YOUR_SUBNET_NAME_2
+        mysql3: REPLACE_WITH_YOUR_SUBNET_NAME_3
+
+iaas_settings:
+  <<: (( merge || nil ))
+
+# NOTE:
+# Replace 10.0.{0,1,2} part of the octet
+# with your network configuration
+  subnet_configs:
+  - name: mysql1
+    type: manual
+    subnets:
+    - range: 10.0.0.0/24
+      gateway: 10.0.0.1
+      reserved:
+      - 10.0.0.2-10.0.0.109
+      - 10.0.0.130-10.0.0.254
+      static:
+        - 10.0.0.120-10.0.0.124
+      dns:
+        - 168.63.129.16
+      cloud_properties:
+        virtual_network_name: (( properties.template_only.azure.virtual_network_name ))
+        subnet_name: (( properties.template_only.azure.subnet_names.mysql1 ))
+  - name: mysql2
+    type: manual
+    subnets:
+    - range: 10.0.1.0/24
+      gateway: 10.0.1.1
+      reserved:
+      - 10.0.1.2-10.0.1.109
+      - 10.0.1.130-10.0.1.254
+      static:
+        - 10.0.1.120-10.0.1.124
+      dns:
+        - 168.63.129.16
+      cloud_properties:
+        virtual_network_name: (( properties.template_only.azure.virtual_network_name ))
+        subnet_name: (( properties.template_only.azure.subnet_names.mysql2 ))
+  - name: mysql3
+    type: manual
+    subnets:
+    - range: 10.0.2.0/24
+      gateway: 10.0.2.1
+      reserved:
+      - 10.0.2.2-10.0.2.109
+      - 10.0.2.130-10.0.2.254
+      static:
+        - 10.0.2.120-10.0.2.124
+      dns:
+        - 168.63.129.16
+      cloud_properties:
+        virtual_network_name: (( properties.template_only.azure.virtual_network_name ))
+        subnet_name: (( properties.template_only.azure.subnet_names.mysql3 ))
+
+  stemcell: &stemcell
+    name: bosh-azure-hyperv-ubuntu-trusty-go_agent
+    version: latest
+  compilation_workers: 4 # When setting this parameter, it overrides the default number of compilation workers (default=4)
+
+  compilation_cloud_properties:
+      instance_type: Standard_F4
+      storage_account_location: (( properties.template_only.azure.region1 ))
+  resource_pool_cloud_properties:
+  - name: mysql_z1
+    cloud_properties:
+      instance_type: Standard_D2_v2
+      storage_account_type: Premium_LRS
+      storage_account_location: (( properties.template_only.azure.region1 ))
+
+  - name: mysql_z2
+    cloud_properties:
+      instance_type: Standard_D2_v2
+      storage_account_type: Premium_LRS
+      storage_account_location: (( properties.template_only.azure.region2 ))
+
+  - name: mysql_z3
+    cloud_properties:
+      instance_type: Standard_D2_v2
+      storage_account_type: Premium_LRS
+      storage_account_location: (( properties.template_only.azure.region3 ))
+
+  - name: arbitrator_z3
+    cloud_properties:
+      instance_type: Standard_D1_v2
+      storage_account_location: (( properties.template_only.azure.region3 ))
+
+  - name: proxy_z1
+    cloud_properties:
+      instance_type: Standard_D1_v2
+      storage_account_location: (( properties.template_only.azure.region1 ))
+
+  - name: proxy_z2
+    cloud_properties:
+      instance_type: Standard_D1_v2
+      storage_account_location: (( properties.template_only.azure.region2 ))
+
+  - name: cf-mysql-broker_z1
+    cloud_properties:
+      instance_type: Standard_D1_v2
+      storage_account_location: (( properties.template_only.azure.region1 ))
+
+  - name: cf-mysql-broker_z2
+    cloud_properties:
+      instance_type: Standard_D1_v2
+      storage_account_location: (( properties.template_only.azure.region2 ))
+
+  - name: errands_z1
+    cloud_properties:
+      instance_type: Standard_D1_v2
+      storage_account_location: (( properties.template_only.azure.region1 ))
+
+  disk_pools:
+  - name: mysql-persistent-disk
+    disk_size: 102_400 # 100 GiB


### PR DESCRIPTION
This new example using the existing AWS and vSphere examples as a
template, but updates them with Azure specific cloud_properties.