### PR TITLE
Arbitrator should be optional

### DIFF
--- a/jobs/mysql/templates/mariadb_ctl_config.yml.erb
+++ b/jobs/mysql/templates/mariadb_ctl_config.yml.erb
@@ -24,7 +24,9 @@ def discover_external_ip
     cluster_ips = ips.compact
   end.else do
     cluster_ips = link('mysql').instances.map { |instance| instance.address }
-    cluster_ips += link('arbitrator').instances.map { |instance| instance.address }
+    if_link('arbitrator') do
+      cluster_ips += link('arbitrator').instances.map { |instance| instance.address }
+    end
   end
 %>
 

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -7,7 +7,9 @@
     cluster_ips = ips.compact
   end.else do
     cluster_ips = link('mysql').instances.map { |instance| instance.address }
-    cluster_ips += link('arbitrator').instances.map { |instance| instance.address }
+    if_link('arbitrator') do
+      cluster_ips += link('arbitrator').instances.map { |instance| instance.address }
+    end
   end
 
   def discover_external_ip


### PR DESCRIPTION
As the arbitrator is not necessary it should be optional to define one.

Signed-off-by: Adrian Kurt <adrian.kurt@swisscom.com>