### PR TITLE
verify-cluster-schemas errand is now using bosh links

### DIFF
--- a/jobs/verify-cluster-schemas/spec
+++ b/jobs/verify-cluster-schemas/spec
@@ -4,6 +4,13 @@ packages:
   - mariadb
   - ruby
   - cluster-schema-verifier
+consumes:
+- name: mysql
+  type: mysql
+  optional: true
+- name: arbitrator
+  type: arbitrator
+  optional: true
 templates:
   run.rb.erb: bin/run
 properties:

--- a/jobs/verify-cluster-schemas/templates/run.rb.erb
+++ b/jobs/verify-cluster-schemas/templates/run.rb.erb
@@ -2,9 +2,22 @@
 
 require '/var/vcap/packages/cluster-schema-verifier/cluster_schema_verifier.rb'
 
+<% 
+  cluster_ips = nil
+  arbitrator_ip = ''
+  if_p('cf_mysql.mysql.cluster_ips') do |ips|
+    cluster_ips = ips.compact
+  end.else do
+    cluster_ips = link('mysql').instances.map { |instance| instance.address }
+    if_link('arbitrator') do
+      arbitrator_ip = link('arbitrator').instances.map { |instance| instance.address }
+    end
+  end
+%>
+
 config = {
-    cluster_ips: <%= p('cf_mysql.mysql.cluster_ips').compact %>,
-    arbitrator_ip: '<%= p('cf_mysql.proxy.arbitrator_ip') %>',
+    cluster_ips: <%= cluster_ips %>,
+    arbitrator_ip: '<%= arbitrator_ip %>',
     mysql_port: <%= p('cf_mysql.mysql.port') %>,
     healthcheck_port: <%= p('cf_mysql.mysql.healthcheck_port') %>,
     mysql_user: '<%= p('cf_mysql.mysql.admin_username') %>',


### PR DESCRIPTION
Errand verify-cluster-schemas should be able to use bosh links.
Arbitrator should be optional.

Signed-off-by: Adrian Kurt <adrian.kurt@swisscom.com>