### PR TITLE
Update comments for kill_and_wait()

### DIFF
--- a/src/cf-mysql-common/pid_utils.sh
+++ b/src/cf-mysql-common/pid_utils.sh
@@ -69,7 +69,7 @@ function wait_pid_death() {
 # @param pidfile
 # @param timeout [default 25s]
 #
-# For a pid found in :pidfile:, send a `kill -6`, then wait for :timeout: seconds to
+# For a pid found in :pidfile:, send a `kill`, then wait for :timeout: seconds to
 # see if it dies on its own. If not, send it a `kill -9`. If the process does die,
 # exit 0 and remove the :pidfile:. If after all of this, the process does not actually
 # die, exit 1.


### PR DESCRIPTION
The default SIGTERM is sent when killing the PID.