### PR TITLE
Upgrade socat version

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -39,10 +39,9 @@ xtrabackup/libtool-2.4.2.tar.gz:
   object_id: 958f3335-2373-4c4f-9db1-7391a9a7e6f2
   sha: 22b71a8b5ce3ad86e1094e7285981cae10e6ff88
   size: 2632347
-xtrabackup/socat-1.7.2.4.tar.gz:
-  object_id: cd877813-c9ac-4596-b4e4-d361fe5bbdb6
-  sha: c33904b83295accef2aaff8adf7eedd3310f9777
-  size: 583762
+xtrabackup/socat-1.7.3.1.tar.gz:
+  size: 606049
+  sha: a6f1d8ab3e85f565dbe172f33a9be6708dd52ffb
 mysqlclient/mariadb-connector-c-2.1.0-src.tar.gz:
   object_id: e1e0446a-8cbd-4b8e-b496-fc20f530fd7c
   sha: 2fea886fd8ddf3e17d6228d282828afeaee0a317

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -39,7 +39,7 @@ xtrabackup/libtool-2.4.2.tar.gz:
   object_id: 958f3335-2373-4c4f-9db1-7391a9a7e6f2
   sha: 22b71a8b5ce3ad86e1094e7285981cae10e6ff88
   size: 2632347
-xtrabackup/socat-1.7.3.1.tar.gz:
+xtrabackup/socat-1.7.3.1.tar.gz: # http://www.dest-unreach.org/socat/download/socat-1.7.3.1.tar.gz
   size: 606049
   sha: a6f1d8ab3e85f565dbe172f33a9be6708dd52ffb
 mysqlclient/mariadb-connector-c-2.1.0-src.tar.gz:

--- a/packages/xtrabackup/packaging
+++ b/packages/xtrabackup/packaging
@@ -10,10 +10,10 @@ export PATH=$PATH:${BOSH_INSTALL_TARGET}/bin:/var/vcap/packages/mariadb/bin
 # Install Xtrabackup runtime dependencies
 
 # socat
-tar xzf xtrabackup/socat-1.7.2.4.tar.gz
+tar xzf xtrabackup/socat-1.7.3.1.tar.gz
 (
   set -e
-  cd socat-1.7.2.4
+  cd socat-1.7.3.1
   ./configure --prefix=$PREFIX
   make
   make install prefix=$PREFIX


### PR DESCRIPTION
This fixes #143 by bumping the socat version to 1.7.3.1

This was tested by running the smoke-tests on bosh-lite. Additionally I did a deployment of `cf-deployment` to AWS, using the default stemcell as well as our custom built openSUSE stemcell. 

The URL of the new blob is: http://www.dest-unreach.org/socat/download/socat-1.7.3.1.tar.gz

I'm not sure about the second commit, adding the URL as comment in the `config/blobs.yml`.