### PR TITLE
Nil the consul link in the example stub

### DIFF
--- a/manifest-generation/examples/job-overrides-consul.yml
+++ b/manifest-generation/examples/job-overrides-consul.yml
@@ -2,10 +2,10 @@ job_overrides:
   colocated_jobs:
     proxy_z1:
       additional_templates:
-        - {release: cf, name: consul_agent}
+        - {release: cf, name: consul_agent, consumes: {consul: nil}}
     proxy_z2:
       additional_templates:
-        - {release: cf, name: consul_agent}
+        - {release: cf, name: consul_agent, consumes: {consul: nil}}
   additional_releases:
   - name: cf
     version: (( release_versions.cf.version || "latest" ))


### PR DESCRIPTION
Once consul-release consumes its own link, the consul_agent will fail to
come up due to the job duplication (that we do to acheive AZs). The
error looks something like the one here: https://diego.ci.cf-app.com/teams/main/pipelines/main/jobs/ketchup-mysql-deploy/builds/216