### PR TITLE
add private key option to download-logs script

### DIFF
--- a/scripts/download-logs
+++ b/scripts/download-logs
@@ -4,12 +4,14 @@ set -eu
 output_dir=${output_dir:-}
 nodes=()
 extra_log_files=""
+ssh_command="ssh"
 
 function usage(){
   >&2 echo "Usage:
   -n (Required) IP address or hostname of the mysql or proxy node to retrieve logs from (can be specified multiple times)
   -d (Required) The output directory
   -X (Optional) Include audit and binary logs
+  -i (Optional) Private SSH key authentication
 
   example:
     ./download-logs -d /tmp -n 10.0.0.1 -n 10.0.0.2
@@ -17,13 +19,16 @@ function usage(){
   exit 1
 }
 
-while getopts "d:n:X" opt; do
+while getopts "d:n:i:X" opt; do
   case $opt in
     d)
       output_dir=$OPTARG
       ;;
     n)
       nodes+=("$OPTARG")
+      ;;
+    i)
+      ssh_command="ssh -i ${OPTARG}"
       ;;
     X)
       extra_log_files="-o -path '/var/vcap/store/mysql/mysql-bin.*' \
@@ -51,7 +56,7 @@ for node in "${nodes[@]}"; do
   # We want to still capture as much data as we can in these cases
   set +e
 
-  ssh "vcap@${node}" "found_paths=(); \
+  $ssh_command "vcap@${node}" "found_paths=(); \
     for path in '/var/vcap/sys/log' '/var/vcap/store/mysql' '/var/vcap/store/mysql_audit_logs'; do \
       if [ -d \${path} ]; then \
         found_paths+=(\${path}); \


### PR DESCRIPTION
It is convenient to have an option which allows passing in the ssh private key manually in cases were ssh-agent is not running and user does not prefer to install the key into the keychain. 

