### PR TITLE
Disable running tests when packaging galera

### DIFF
--- a/packages/galera/packaging
+++ b/packages/galera/packaging
@@ -24,7 +24,7 @@ PATH=$PATH:/var/vcap/packages/python/bin
 # Go Agent cannot handle more than 10MB output, so trim it
 #
 set +e
-/var/vcap/packages/scons/bin/scons > build.out 2> build.err
+/var/vcap/packages/scons/bin/scons tests=0 > build.out 2> build.err
 BUILD_EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
The tests don't actually give much value (they're more useful when modifying the source code of the package, not when rebuilding known-good source code).  Worse, some of the tests are timing-dependent.  See also upstream's `GALERA_TEST_DETERMINISTIC` flag.

Disabling the tests should not affect the output of the build.