### PR TITLE
Fix link to instructions for deploying release

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To trust self-signed SSL certificates, you can change `jobs.cf-mysql-broker.skip
 ## Downloading a Stable Release
 
 Stable releases, also known as final releases, are available for general use. Release notes and source code are available on [github](https://github.com/cloudfoundry/cf-mysql-release/releases).
-Instructions for uploading a final release to your BOSH director can be found on [bosh.io](bosh.io/releases/github.com/cloudfoundry/cf-mysql-release).
+Instructions for uploading a final release to your BOSH director can be found on [bosh.io](https://bosh.io/releases/github.com/cloudfoundry/cf-mysql-release).
 
 **Note:** If your BOSH director's able to access the Internet, you don't need to download and upload a release to your BOSH director. When using [cf-mysql-deployment](https://github.com/cloudfoundry/cf-mysql-deployment), the correct release is referenced in the manifest, and will be automatically retrieved by the BOSH director.
 


### PR DESCRIPTION
It was missing a scheme, and would result in a GitHub 404.