### PR TITLE
add performance_schema property

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,4 +66,25 @@ Note 1: If a seeded database is renamed in the manifest, a new database will be 
 
 Note 2: If all you need is a database deployment, it is possible to deploy this
 release with zero broker instances and completely remove any dependencies on Cloud Foundry.
-See the [proxy](jobs/proxy/spec) and [acceptance-tests](jobs/acceptance-tests/spec) spec files for standalone configuration options.
+See the [proxy](jobs/proxy/spec) and [acceptance-tests](jobs/acceptance-tests/spec) spec files for standalone configuration options.  
+
+## Instance tuning ##
+### Performance schema ###
+
+The Performance Schema is a feature for monitoring server performance, see related mariadb documentation : [https://mariadb.com/kb/en/library/performance-schema/](https://mariadb.com/kb/en/library/performance-schema/ "https://mariadb.com/kb/en/library/performance-schema/").   
+Performance_schema database, consists of a number of tables that can be queried with regular SQL statements, returning specific performance information.  
+
+To activate Performance_schema, update `cf_mysql.mysql.performance_schema_enabled` property in mysql instance group.  
+
+Performance_schema uses a memory engine (performance_schema) which can potentially increase memory usage when enabled.  
+To see memory used by performance_schema in bytes:
+   
+```
+MariaDB [(none)]> show engine performance_schema status;  
++--------------------+--------------------------------------------------------------+----------+  
+| Type               | Name                                                         | Status   |  
++--------------------+--------------------------------------------------------------+----------+  
+...
+| performance_schema | performance_schema.memory                                    | 68024448 |
++--------------------+--------------------------------------------------------------+----------+ 
+```

--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -256,3 +256,7 @@ properties:
   cf_mysql.mysql.enable_galera:
     default: true
     description: 'Advanced feature. Only use this when deploying a single MySQL node with no intention to run any other components of cf-mysql-release.'
+
+  cf_mysql.mysql.performance_schema_enabled:
+    default: false
+    description: "Enables Mariadb Performance Schema when set to true"

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -210,7 +210,7 @@ performance_schema_max_mutex_classes                   = 200
 performance_schema_max_rwlock_classes                  = 40
 performance_schema_max_socket_classes                  = 10
 performance_schema_max_stage_classes                   = 150
-performance_schema_max_statement_classes               = 168
+performance_schema_max_statement_classes               = 178
 performance_schema_max_thread_classes                  = 50
 # indicates how many different users, hosts, or accounts (combinations of 'user_name'@'host_name') are expected to connect to the server.
 performance_schema_accounts_size                       = 100

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -201,6 +201,47 @@ ssl_cert                        = /var/vcap/jobs/mysql/certificates/server-cert.
 ssl_key                         = /var/vcap/jobs/mysql/certificates/server-key.pem
 <% end %>
 
+<% if p('cf_mysql.mysql.performance_schema_enabled') %>
+performance_schema              = ON
+# Specifies the maximum number of each instrument
+performance_schema_max_cond_classes                    = 80
+performance_schema_max_file_classes                    = 50
+performance_schema_max_mutex_classes                   = 200
+performance_schema_max_rwlock_classes                  = 40
+performance_schema_max_socket_classes                  = 10
+performance_schema_max_stage_classes                   = 150
+performance_schema_max_statement_classes               = 168
+performance_schema_max_thread_classes                  = 50
+# indicates how many different users, hosts, or accounts (combinations of 'user_name'@'host_name') are expected to connect to the server.
+performance_schema_accounts_size                       = 100
+performance_schema_hosts_size                          = 100
+performance_schema_users_size                          = 100
+# affect directly how much memory is used to keep historical data, but have no impact on CPU. 
+performance_schema_events_stages_history_long_size     = 1000
+performance_schema_events_stages_history_size          = 10
+performance_schema_events_statements_history_long_size = 1000
+performance_schema_events_statements_history_size      = 10
+performance_schema_events_waits_history_long_size      = 10000
+performance_schema_events_waits_history_size           = 10
+#
+performance_schema_max_cond_instances                  = 1258
+performance_schema_max_file_handles                    = 32768
+performance_schema_max_file_instances                  = 6250
+performance_schema_max_mutex_instances                 = 5133 
+performance_schema_max_rwlock_instances                = 2765
+performance_schema_max_table_handles                   = 366
+performance_schema_max_table_instances                 = 587
+performance_schema_max_socket_instances                = 230
+performance_schema_max_thread_instances                = 288
+#
+performance_schema_setup_actors_size                   = 100
+performance_schema_setup_objects_size                  = 100
+performance_schema_session_connect_attrs_size          = 512
+performance_schema_digests_size                        = 5000
+<% else %>
+performance_schema              = OFF
+<% end %>    
+
 [mysqldump]
 quick
 quote-names


### PR DESCRIPTION
This PR optionally enables operators to enable performance_schema feature in MariaDB. This requires setting the `cf_mysql.mysql.performance_schema_enabled` property to true in mysql instance group (default is false)

In MariaDB distribution , by default performance_schema is OFF since 10.0.12. See doc [performance_schema](https://mariadb.com/kb/en/library/performance-schema-system-variables/#performance_schema)

The performance_schema instrument flags (e.g. `performance_schema_max_file_handles`) are given sensible defaults based on Orange production usage (which sometimes slightly differ from mariadb defaults). Documentation mentions possible memory impact of turning on the feature and ways to measure it. 

### Background 

The Performance Schema is a feature for monitoring server performance, see [related mariadb documentation](https://mariadb.com/kb/en/library/performance-schema/).

`Performance_schema` database, consists of a number of tables that can be queried with regular SQL statements, returning specific performance information. 

Numerous community monitoring tools leverage the Performance Schema feature, such as :
* [Collector Flags](https://github.com/prometheus/mysqld_exporter#collector-flags) of prometheus mysql exporter
* Graphana dashboard (e.g. [Percona plugin](https://github.com/percona/grafana-dashboards/blob/master/dashboards/MySQL_Performance_Schema.json))

This PR replaces #188 