### PR TITLE
add performance_schema property

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,3 +74,22 @@ See the [proxy](jobs/proxy/spec) and [acceptance-tests](jobs/acceptance-tests/sp
 The slow query log is enabled and you can find long query exceeded 10 seconds (by default) in `/var/vcap/sys/log/mysql/mysql_slow_query.log`
 
 To change the threshold above which SQL queries get logged in the slow query log file, update  `cf_mysql.mysql.long_query_time` (time in seconds/microseconds).
+
+### Performance schema ###
+
+The Performance Schema is a feature for monitoring server performance, see related mariadb documentation : [https://mariadb.com/kb/en/library/performance-schema/](https://mariadb.com/kb/en/library/performance-schema/ "https://mariadb.com/kb/en/library/performance-schema/").   
+Performance_schema database, consists of a number of tables that can be queried with regular SQL statements, returning specific performance information.  
+
+To activate Performance_schema, update `cf_mysql.mysql.performance_schema_enabled` property in mysql instance group.  
+
+Performance_schema uses a memory engine (performance_schema) which can potentially increase memory usage when enabled.  
+To see memory used by performance_schema in bytes:
+   
+```
+MariaDB [(none)]> show engine performance_schema status;  
++--------------------+--------------------------------------------------------------+-----------+  
+| Type               | Name                                                         |  Status   |  
++--------------------+--------------------------------------------------------------+-----------+  
+...
+| performance_schema | performance_schema.memory                                    | 131117680 |
++--------------------+--------------------------------------------------------------+-----------+ 

--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -256,3 +256,6 @@ properties:
     default: 10
     description: 'Threshold in seconds above which SQL queries get logged in the slow query log file'
 
+  cf_mysql.mysql.performance_schema_enabled:
+    default: false
+    description: "Enables Mariadb Performance Schema when set to true"

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -202,6 +202,20 @@ ssl_cert                        = /var/vcap/jobs/mysql/certificates/server-cert.
 ssl_key                         = /var/vcap/jobs/mysql/certificates/server-key.pem
 <% end %>
 
+<% if p('cf_mysql.mysql.performance_schema_enabled') %>
+performance_schema              = ON
+# Specifies the maximum number of few instruments to limit memory consumption under 125Mb with 1500 connections
+performance_schema_max_cond_instances   = 1270         #Specifies the maximum number of instrumented condition objects.       (default automated sizing : 2540)
+performance_schema_max_mutex_instances  = 2215         #Specifies the maximum number of instrumented mutex instances.         (default automated sizing : 8860)
+performance_schema_max_rwlock_instances = 1000         #Specifies the maximum number of instrumented rwlock objects.          (default automated sizing : 4620)
+performance_schema_max_socket_instances = 230          #Specifies the maximum number of instrumented socket objects.          (default automated sizing : 640)
+performance_schema_max_table_handles    = 1000         #Specifies the maximum number of opened table objects                  (default automated sizing : 2000)       
+performance_schema_max_table_instances  = 1000         #Specifies the maximum number of instrumented table objects            (default automated sizing : 12500)    
+performance_schema_max_thread_instances = 360          #Specifies how many of the running server threads can be instrumented. (default automated sizing : 720) 
+<% else %>
+performance_schema              = OFF
+<% end %> 
+
 [mysqldump]
 quick
 quote-names


### PR DESCRIPTION
This PR optionally enables operators to enable performance_schema feature in MariaDB. This requires setting the `cf_mysql.mysql.performance_schema_enabled` property to true in mysql instance group (default is false)

In MariaDB distribution , by default performance_schema is OFF since 10.0.12. See doc [performance_schema](https://mariadb.com/kb/en/library/performance-schema-system-variables/#performance_schema)

The performance_schema instrument flags (e.g. `performance_schema_max_file_handles`) are given sensible defaults based on Orange production usage (which sometimes slightly differ from mariadb defaults).

Documentation mentions possible memory impact of turning on the feature and ways to measure it. 
We need to specifie the maximum number of few instruments to limit memory consumption under 125Mb (instead of  660Mb) with 1500 connections :
```sql
performance_schema_max_cond_instances   = 1270         (default automated sizing : 2540)
performance_schema_max_mutex_instances  = 2215         (default automated sizing : 8860)
performance_schema_max_rwlock_instances = 1000         (default automated sizing : 4620)
performance_schema_max_socket_instances = 230          (default automated sizing : 640)
performance_schema_max_table_handles    = 1000         (default automated sizing : 2000)       
performance_schema_max_table_instances  = 1000         (default automated sizing : 12500)    
performance_schema_max_thread_instances = 360          (default automated sizing : 720) 
```

### Background 

The Performance Schema is a feature for monitoring server performance, see [related mariadb documentation](https://mariadb.com/kb/en/library/performance-schema/).

`Performance_schema` database, consists of a number of tables that can be queried with regular SQL statements, returning specific performance information. 

Numerous community monitoring tools leverage the Performance Schema feature, such as :
* [Collector Flags](https://github.com/prometheus/mysqld_exporter#collector-flags) of prometheus mysql exporter
* Graphana dashboard (e.g. [Percona plugin](https://github.com/percona/grafana-dashboards/blob/master/dashboards/MySQL_Performance_Schema.json))

This PR replaces #190 
