### PR TITLE
Add cluster health check to drain script before shutting down local node 

### DIFF
--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -4,6 +4,8 @@ name: mysql
 templates:
   disable_mysql_cli_history.sh.erb: config/disable_mysql_cli_history.sh
   drain.sh: bin/drain
+  drain_user_setup.sql.erb: config/drain_user_setup.sql
+  drain.cnf.erb: config/drain.cnf
   mariadb_ctl.erb: bin/mariadb_ctl
   my.cnf.erb: config/my.cnf
   mylogin.cnf.erb: config/mylogin.cnf
@@ -204,6 +206,9 @@ properties:
     default: 9200
   cf_mysql.mysql.galera_healthcheck.db_password:
     description: 'Password used by the sidecar to connect to the database'
+
+  cf_mysql.mysql.drain.db_password:
+    description: 'Password used by the drain script to connect to the database. Use bosh "--skip-drain" flag when need to update drain db_password'
 
   cf_mysql.mysql.disable_auto_sst:
     description: 'When disable_auto_sst is true, nodes unable to IST will be prevented from automatically deleting their data and performing an SST'

--- a/jobs/mysql/templates/drain.cnf.erb
+++ b/jobs/mysql/templates/drain.cnf.erb
@@ -1,0 +1,3 @@
+[client]
+user="drain"
+password="<%= p('cf_mysql.mysql.drain.db_password') %>"

--- a/jobs/mysql/templates/drain.sh
+++ b/jobs/mysql/templates/drain.sh
@@ -55,12 +55,5 @@ for NODE in "${CLUSTER_NODES[@]}"; do
   fi
 done
 
-<% if p('cf_mysql_enabled') == true %>
-/var/vcap/packages/mariadb/support-files/mysql.server stop --pid-file=/var/vcap/sys/run/mysql/mysql.pid > /dev/null
-return_code=$?
-echo 0
-exit ${return_code}
-<% else %>
-echo 0
-exit 0
-<% end %>
+echo "Drain Success" &>> "$LOG_DIR/drain.log"
+echo 0; exit 0 # drain success

--- a/jobs/mysql/templates/drain.sh
+++ b/jobs/mysql/templates/drain.sh
@@ -1,41 +1,66 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
 
-NODE_IP=<%= spec.ip %>
-MYSQL_PORT=<%= p("cf_mysql.mysql.port") %>
+set -e -o pipefail
 
-LOG_DIR="/var/vcap/sys/log/mysql/"
+<%
+  require "shellwords"
 
-# if the node ain't running, ain't got nothin' to drain
-if ! ps -p $(</var/vcap/sys/run/mysql/mysql.pid) >/dev/null; then
-  echo "mysql is not running: drain OK" &>> "$LOG_DIR/drain.log"
-  echo 0; exit 0 # drain success
-fi
+  cluster_ips = link('mysql').instances.map(&:address)
+  if_link('arbitrator') do
+    cluster_ips += link('arbitrator').instances.map(&:address)
+  end
+%>
+
+CLUSTER_NODES=(<%= cluster_ips.map{|e| Shellwords.escape e}.join(' ') %>)
+MYSQL_PORT=<%= Shellwords.escape p("cf_mysql.mysql.port") %>
+
+function prepend_datetime() {
+  awk -W interactive '{ system("echo -n [$(date +%FT%T%z)]"); print " " $0 }'
+}
 
 function wsrep_var() {
-  local var_name=$1
-  local host=$2
-  local port=$3
+  local var_name="$1"
+  local host="$2"
   if [[ $var_name =~ ^wsrep_[a-z_]+$ ]]; then
     timeout 5 \
-      /usr/local/bin/mysql --defaults-file=/var/vcap/jobs/mysql/config/drain.cnf -h "$host" -P "$port" \
-      --execute="SHOW STATUS LIKE '$var_name'" -N |\
-      awk '{print $2}' | tr -d '\n'
+      /usr/local/bin/mysql --defaults-file=/var/vcap/jobs/mysql/config/drain.cnf -h "$host" -P "$MYSQL_PORT" \
+      --execute="SHOW STATUS LIKE '$var_name'" -N \
+      | awk '{print $2}' \
+      | tr -d '\n'
   fi
 }
 
-CLUSTER_NODES=(`wsrep_var wsrep_incoming_addresses $NODE_IP $MYSQL_PORT | sed -e 's/,/ /g'`)
+LOG_DIR="/var/vcap/sys/log/mysql"
 
-# check if all nodes are part of the PRIMARY component; if not then
+exec 3>&1
+exec \
+  1> >(prepend_datetime >> $LOG_DIR/drain.out.log) \
+  2> >(prepend_datetime >> $LOG_DIR/drain.err.log)
+
+# if the node ain't running, ain't got nothin' to drain
+if ! ps -p $(</var/vcap/sys/run/mysql/mysql.pid) >/dev/null; then
+  echo "mysql is not running: drain OK"
+  echo 0 >&3; exit 0 # drain success
+fi
+
+# Check each cluster node's availability.
+# Jump to next node if unreachable(timeout 5 sec), then do not add it as test component.
+# Node may have been deleted or mysql port has been updated.
+for NODE in "${CLUSTER_NODES[@]}"; do
+  { nc -zv -w 5 $NODE $MYSQL_PORT \
+  && CLUSTER_TEST_NODES=(${CLUSTER_TEST_NODES[@]} $NODE); } \
+  || continue
+done
+
+# Check if all nodes are part of the PRIMARY component; if not then
 # something is terribly wrong (loss of quorum or split-brain) and doing a
 # rolling restart can actually cause data loss (e.g. if a node that is out
 # of sync is used to bootstrap the cluster): in this case we fail immediately.
-for NODE in "${CLUSTER_NODES[@]}"; do
-  NODE_IP=`echo $NODE | cut -d ":" -f 1`
-  NODE_PORT=`echo $NODE | cut -d ":" -f 2`
-  cluster_status=`wsrep_var wsrep_cluster_status $NODE_IP $NODE_PORT`
-  if [ "$cluster_status" != "Primary" ]; then
-    echo "wsrep_cluster_status of node '$NODE_IP' is '$cluster_status' (expected 'Primary'): drain failed" &>> "$LOG_DIR/drain.log"
-    exit 1 # drain failed
+for TEST_NODE in "${CLUSTER_TEST_NODES[@]}"; do
+  cluster_status=$(wsrep_var wsrep_cluster_status "$TEST_NODE")
+  if [ "$cluster_status" != Primary ]; then
+    echo "wsrep_cluster_status of node '$TEST_NODE' is '$cluster_status' (expected 'Primary'): drain failed"
+    exit -1 # drain failed
   fi
 done
 
@@ -44,16 +69,14 @@ done
 # Consider a 3 node cluster: if node1 is donor for node2 and we shut down node3
 # -that is synced- then node1 is joining, node2 is donor and node3 is down: as
 # a result the cluster lose quorum until node1/node2 complete the transfer!)
-for NODE in "${CLUSTER_NODES[@]}"; do
-  NODE_IP=`echo $NODE | cut -d ":" -f 1`
-  NODE_PORT=`echo $NODE | cut -d ":" -f 2`
-  state=`wsrep_var wsrep_local_state_comment $NODE_IP $NODE_PORT`
-  if [ "$state" != "Synced" ]; then
-    echo "wsrep_local_state_comment of node '$NODE_IP' is '$state' (expected 'Synced'): retry drain in 5 seconds" &>> "$LOG_DIR/drain.log"
+for TEST_NODE in "${CLUSTER_TEST_NODES[@]}"; do
+  state=$(wsrep_var wsrep_local_state_comment "$TEST_NODE")
+  if [ "$state" != Synced ]; then
+    echo "wsrep_local_state_comment of node '$TEST_NODE' is '$state' (expected 'Synced'): retry drain in 5 seconds"
     # TODO: rewrite to avoid using dynamic drain (soon to be deprecated)
-    echo -5 # retry in 5 seconds
+    echo -5 >&3; exit 0 # retry in 5 seconds
   fi
 done
 
-echo "Drain Success" &>> "$LOG_DIR/drain.log"
-echo 0; exit 0 # drain success
+echo "Drain Success"
+echo 0 >&3; exit 0 # drain success

--- a/jobs/mysql/templates/drain.sh
+++ b/jobs/mysql/templates/drain.sh
@@ -1,4 +1,59 @@
-#!/bin/bash -e
+#!/bin/bash -eu
+
+NODE_IP=<%= spec.ip %>
+MYSQL_PORT=<%= p("cf_mysql.mysql.port") %>
+
+LOG_DIR="/var/vcap/sys/log/mysql/"
+
+# if the node ain't running, ain't got nothin' to drain
+if ! ps -p $(</var/vcap/sys/run/mysql/mysql.pid) >/dev/null; then
+  echo "mysql is not running: drain OK" &>> "$LOG_DIR/drain.log"
+  echo 0; exit 0 # drain success
+fi
+
+function wsrep_var() {
+  local var_name=$1
+  local host=$2
+  local port=$3
+  if [[ $var_name =~ ^wsrep_[a-z_]+$ ]]; then
+    timeout 5 \
+      /usr/local/bin/mysql --defaults-file=/var/vcap/jobs/mysql/config/drain.cnf -h "$host" -P "$port" \
+      --execute="SHOW STATUS LIKE '$var_name'" -N |\
+      awk '{print $2}' | tr -d '\n'
+  fi
+}
+
+CLUSTER_NODES=(`wsrep_var wsrep_incoming_addresses $NODE_IP $MYSQL_PORT | sed -e 's/,/ /g'`)
+
+# check if all nodes are part of the PRIMARY component; if not then
+# something is terribly wrong (loss of quorum or split-brain) and doing a
+# rolling restart can actually cause data loss (e.g. if a node that is out
+# of sync is used to bootstrap the cluster): in this case we fail immediately.
+for NODE in "${CLUSTER_NODES[@]}"; do
+  NODE_IP=`echo $NODE | cut -d ":" -f 1`
+  NODE_PORT=`echo $NODE | cut -d ":" -f 2`
+  cluster_status=`wsrep_var wsrep_cluster_status $NODE_IP $NODE_PORT`
+  if [ "$cluster_status" != "Primary" ]; then
+    echo "wsrep_cluster_status of node '$NODE_IP' is '$cluster_status' (expected 'Primary'): drain failed" &>> "$LOG_DIR/drain.log"
+    exit 1 # drain failed
+  fi
+done
+
+# Check if all nodes are synced: if not we wait and retry
+# This check must be done against *ALL* nodes, not just against the local node.
+# Consider a 3 node cluster: if node1 is donor for node2 and we shut down node3
+# -that is synced- then node1 is joining, node2 is donor and node3 is down: as
+# a result the cluster lose quorum until node1/node2 complete the transfer!)
+for NODE in "${CLUSTER_NODES[@]}"; do
+  NODE_IP=`echo $NODE | cut -d ":" -f 1`
+  NODE_PORT=`echo $NODE | cut -d ":" -f 2`
+  state=`wsrep_var wsrep_local_state_comment $NODE_IP $NODE_PORT`
+  if [ "$state" != "Synced" ]; then
+    echo "wsrep_local_state_comment of node '$NODE_IP' is '$state' (expected 'Synced'): retry drain in 5 seconds" &>> "$LOG_DIR/drain.log"
+    # TODO: rewrite to avoid using dynamic drain (soon to be deprecated)
+    echo -5 # retry in 5 seconds
+  fi
+done
 
 <% if p('cf_mysql_enabled') == true %>
 /var/vcap/packages/mariadb/support-files/mysql.server stop --pid-file=/var/vcap/sys/run/mysql/mysql.pid > /dev/null

--- a/jobs/mysql/templates/drain_user_setup.sql.erb
+++ b/jobs/mysql/templates/drain_user_setup.sql.erb
@@ -1,0 +1,5 @@
+<%
+  node_ip = spec.ip
+  hosts = (node_ip.split(".")[0..-2] + ["%"]).join('.')
+%>
+GRANT USAGE ON mysql.* TO 'drain'@'<%= hosts %>' IDENTIFIED BY '<%= p('cf_mysql.mysql.drain.db_password') %>'

--- a/jobs/mysql/templates/mariadb_ctl.erb
+++ b/jobs/mysql/templates/mariadb_ctl.erb
@@ -102,7 +102,6 @@ case $1 in
     echo "stop script: stopping mariadb_ctrl..."
 
     echo "stop script: stopping node $JOB_INDEX"
-    #kill -9 $(cat $PIDFILE)
     /var/vcap/packages/mariadb/support-files/mysql.server stop --pid-file=/var/vcap/sys/run/mysql/mysql.pid
     rm $PIDFILE
     echo "stop script: completed stopping mariadb_ctrl"

--- a/jobs/mysql/templates/mariadb_ctl_config.yml.erb
+++ b/jobs/mysql/templates/mariadb_ctl_config.yml.erb
@@ -39,6 +39,7 @@ Db:
     Password: <%= seed["password"] %>
   <% end %>
   PostStartSQLFiles:
+  - /var/vcap/jobs/mysql/config/drain_user_setup.sql
   - /var/vcap/jobs/mysql/config/galera_healthcheck_setup.sql
   - /var/vcap/jobs/mysql/config/cluster_health_logger_setup.sql
   Socket: /var/vcap/sys/run/mysql/mysqld.sock


### PR DESCRIPTION
Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry/cf-mysql-release/blob/develop/CONTRIBUTING.md), including signing the Contributor License Agreement.

# Feature or Bug Description
Amended mysql drain script to check cluster nodes health before allowing local node to shutdown.

# Motivation
We think this adds safeness to update cluster when it is being check on drain before shutting down local node.

# Related Issue
https://github.com/cloudfoundry/cf-mysql-release/issues/208

