### PR TITLE
Add `cf_mysql.mysql.bootstrap_enabled` property

### DIFF
--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -256,7 +256,7 @@ properties:
     default: 10
     description: 'Threshold in seconds above which SQL queries get logged in the slow query log file'
 
-  cf_mysql.mysql.bootstrap_enabled
+  cf_mysql.mysql.bootstrap_enabled:
     default: true 
     description: 'Enables ussage of bootsrap procedure'
 

--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -256,3 +256,7 @@ properties:
     default: 10
     description: 'Threshold in seconds above which SQL queries get logged in the slow query log file'
 
+  cf_mysql.mysql.bootstrap_enabled
+    default: true 
+    description: 'Enables ussage of bootsrap procedure'
+

--- a/jobs/mysql/templates/mariadb_ctl_config.yml.erb
+++ b/jobs/mysql/templates/mariadb_ctl_config.yml.erb
@@ -51,5 +51,5 @@ Manager:
   <% cluster_ips.each do |ip| %>
   - <%= ip %>
   <% end %>
-  BootstrapNode: <%= spec.bootstrap %>
+  BootstrapNode: <%= spec.bootstrap && p("cf_mysql.mysql.bootstrap_enabled") %>
   ClusterProbeTimeout: <%= p('cf_mysql.mysql.cluster_probe_timeout') %>


### PR DESCRIPTION
Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry/cf-mysql-release/blob/develop/CONTRIBUTING.md), including signing the Contributor License Agreement.

# Feature or Bug Description
It provides a way to disable bootstrap for the first instance in an instance group

# Motivation
I am using multi-cpi feature of bosh to deploy mysql cluster in 2 separate vsphere datacenters. Because of the fact that I use 2 separate datacenters, I have to split the mysql instance group into 2 separate instance groups, where each group is configured with its own AS and bosh network. I use a manual link to prepare `mysql` link in such a way that it contains combined set of all ips from both instance groups. However, I still need to disable bootstrap on the first instance of the second instance group - If I don't do that I will end up with 2 separate clusters, instead of a single one.

