### PR TITLE
Optional enable_drain_healthcheck, removed status code 000 check

### DIFF
--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -84,7 +84,7 @@ properties:
     description: 'Maximum total number of database connections for the node'
     default: 1500
   cf_mysql.mysql.enable_drain_healthcheck:
-    description: 'When this is enabled, the --skip-drain flag is required in order to delete a deployment. Drain healthcheck cannot be enabled when using the arbitrator. Enabling this ensures mysql nodes will verify the health of all other nodes before draining.'
+    description: 'When this is enabled, the --skip-drain flag is required in order to delete a deployment and scaling down of instances. Drain healthcheck cannot be enabled when using the arbitrator. Enabling this ensures mysql nodes will verify the health of all other nodes before draining.'
     default: false
   cf_mysql.mysql.tls.ca_certificate:
     description: 'CA Certificate which signed the server certificate'

--- a/jobs/mysql/templates/drain.sh
+++ b/jobs/mysql/templates/drain.sh
@@ -26,7 +26,7 @@ for NODE in "${CLUSTER_NODES[@]}"; do
   set +e
   status_code=$(curl -s -o "/dev/null" -w "%{http_code}" "$NODE:$GALERA_HEALTHCHECK_PORT")
   set -e
-  if [[ $status_code -eq 000 || $status_code -eq 200 ]]; then
+  if [ $status_code -eq 200 ]; then
     continue
   else
     echo "$(date): galera heathcheck returned $status_code; drain failed on node ${NODE}" >> "${LOG_DIR}/drain.err.log"


### PR DESCRIPTION
# Feature or Bug Description
Removed `000` here https://github.com/cloudfoundry/cf-mysql-release/blob/4c657b38ff7998c46e89d9163baee80b891a9d5a/jobs/mysql/templates/drain.sh#L32

Update put on spec desc, "---skip-drain flag is required in order to delete a deployment" then add "scaling down"

# Motivation
Drain script will be more useful to make sure that cluster is healthy before shutting down the local node. Unlike when `000` is added, we assume its scaling down but its not always the case. It could be a node left network/connectivity issue, crashed node, or bosh monit stopped node.

# Related Issue
https://github.com/cloudfoundry/cf-mysql-release/issues/208
https://github.com/cloudfoundry/cf-mysql-release/pull/209
https://github.com/cloudfoundry/cf-mysql-release/pull/209#issuecomment-411437840

