### PR TITLE
add cf_mysql.mysql.extra_max_connections and cf_mysql.mysql.extra_por…

### DIFF
--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -83,6 +83,12 @@ properties:
   cf_mysql.mysql.max_connections:
     description: 'Maximum total number of database connections for the node'
     default: 1500
+  cf_mysql.extra_max_connections
+    description: 'The number of connections on the extra_port, additional to cf_mysql.mysql.max_connections'
+    default: 1
+  cf_mysql.extra_port
+    description: 'Extra port number to use for tcp-connections in a one-thread-per-connection manner. See also cf_mysql.extra_max_connections.'
+    default: 0
   cf_mysql.mysql.enable_drain_healthcheck:
     description: 'When this is enabled, the --skip-drain flag is required in order to delete a deployment. Drain healthcheck cannot be enabled when using the arbitrator. Enabling this ensures mysql nodes will verify the health of all other nodes before draining.'
     default: false

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -193,6 +193,8 @@ innodb_flush_method             = <%= innodb_flush_method %>
 innodb_log_buffer_size          = <%= p('cf_mysql.mysql.innodb_log_buffer_size') %>
 
 max_connections                 = <%= p('cf_mysql.mysql.max_connections') %>
+extra_max_connections		= <%= p('cf_mysql.mysql.extra_max_connections') %>
+extra_port			= <%= p('cf_mysql.mysql.extra_port') %>
 
 # Event Scheduler
 event_scheduler                 = <%= p('cf_mysql.mysql.event_scheduler') %>


### PR DESCRIPTION
…t in case Admin is locked out with too_many_connections

We set max_connections to 15k. It happened that this limit is reached and we as admins couldn't identify which component flooding the Galera. It was the mgmt database for Cloud Foundry and Swisscom developed components.

For Galera DBaaS we limit max connections with SB.

This PR is tested with extra_max_connections = 10 and extra_port = 2000. The admin could login even max_connections was reached and normal users couldn't login.

thanks

cheers
GETandSELECT