### PR TITLE
Manage paid and free plan

### DIFF
--- a/jobs/cf-mysql-broker/templates/settings.yml.erb
+++ b/jobs/cf-mysql-broker/templates/settings.yml.erb
@@ -52,6 +52,9 @@ production:
 
         <% max_user_connections = plan['max_user_connections'] || p('cf_mysql.broker.max_user_connections_default') %>
         max_user_connections: <%= max_user_connections %>
+        <% if !plan['free'].nil? %>
+        free: <%= plan['free'] %>
+        <% end %>
 
         <%
         if !plan['metadata']


### PR DESCRIPTION
### Can not display the cost associated with a plan in the marketplace  
If a price is associated with a plan,the "**free**" field must be fill with the value "**false**" in the section "**plan of the service**" in the deployment manifest. 
This information must be sent from the manifest to the Mysql broker via the `**setting.yml**` file.

This PR adjusts the script code **setting.yml.erb** to meet the need.

This PR is associated with the #22 PR of cf-mysql-broker