### PR TITLE
Manage currencies other than Usd

### DIFF
--- a/jobs/cf-mysql-broker/templates/settings.yml.erb
+++ b/jobs/cf-mysql-broker/templates/settings.yml.erb
@@ -78,9 +78,11 @@ production:
           <% else %>
           costs:
           <% costs.each do |cost| %>
-            - amount:
-                usd: <%= cost['amount']['usd'] %>
-              unit: <%= cost['unit'] %>
+          - amount:
+            <% cost['amount'].each do |currency, value| %>
+              <%= currency %>: <%= value %>
+            <% end %>
+            unit: <%= cost['unit'] %>
           <% end %>
           <% end %>
 


### PR DESCRIPTION
### Management of currencies other than Usd for the display of prices associated with each plan in the Cloudfoundry marketplace.
Currently, the MySql release does not display the price associated with a plan in a currency other than **USD**.
The currency information is not correctly passed from the deployment manifest to the **setting.ym**l file in the config of the cf-mysql-broker job.
This PR resolves this dysfunction
