### PR TITLE
Tighten up IPsec monit check

### DIFF
--- a/jobs/mysql/templates/mariadb_ctl.erb
+++ b/jobs/mysql/templates/mariadb_ctl.erb
@@ -59,7 +59,7 @@ case $1 in
     # Ensure that if IPsec is present, it is running before we try to start
     set +e
     ipsec_path=$(ls /var/vcap/packages/strongswan*/sbin/ipsec | head -1)
-    ipsec_monit_job=$(/var/vcap/bosh/bin/monit summary | grep ipsec)
+    ipsec_monit_job=$(/var/vcap/bosh/bin/monit summary | grep "^Process[[:space:]]'ipsec'")
     if [ -n "${ipsec_monit_job}" ]; then
       $ipsec_path status
       ipsec_status=$?


### PR DESCRIPTION
Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry/cf-mysql-release/blob/develop/CONTRIBUTING.md), including signing the Contributor License Agreement.

This PR fixes an issue where the mariadb_ctl script incorrectly exits with "Exiting for restart because IPsec is present but not yet running" message if the vm hostname contain "ipsec"

Command to check IPsec job is `/var/vcap/bosh/bin/monit summary | grep ipsec` is too permissive. In our case it captured `System 'system_vm-b7770176-d990-4543-64af-3f9439760ba8.c.cf-xxx-xxx-ipsec.internal' running` 




