### PR TITLE
add-variable-log-warnings

### DIFF
--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -87,6 +87,7 @@ tmpdir                          = /var/vcap/data/mysql/tmp
 language                        = /var/vcap/packages/mariadb/share
 pid-file                        = /var/vcap/sys/run/mysql/mysql.pid
 log_error                       = /var/vcap/sys/log/mysql/mysql.err.log
+log_warnings                    = 2
 init_file                       = /var/vcap/jobs/mysql/config/mariadb_init
 skip_external_locking           = TRUE
 symbolic-links                  = OFF


### PR DESCRIPTION
# Feature or Bug Description
Add server system variable MariaDB `log_warnings=2` (log level)

# Motivation
Security rules need to log more information than default (1). With level 2, we have   
- Access denied errors.
- Connections aborted or closed due to errors or timeouts.
- Table handler errors  

See [MariaDB documentation](https://mariadb.com/kb/en/library/server-system-variables/#log_warnings)



